### PR TITLE
Update CONTRIBUTING now that we've decided on licensing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,16 @@
 # Contributing
 
-We (Chef Software, Inc.) are currently discussing whether to change the
-license on the packaging code in this repository to MIT. Until we make a
-decision, we cannot accept contributions from outside our organization.
-We should have this resolved very soon.
+## Summary
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
+## Licensing
+
+Gecode itself is MIT licensed. If you make changes to the vendored
+Gecode source in ext/libgecode3/vendor, your changes will we distributed
+under the terms of the MIT license. All other code in this repository is
+distributed under the terms of the Apache 2.0 license.


### PR DESCRIPTION
We've decided that the package wrapping stuff will be licensed as Apache 2.0.
