### PR TITLE
Cleanup after gecode compile

### DIFF
--- a/ext/libgecode3/extconf.rb
+++ b/ext/libgecode3/extconf.rb
@@ -81,7 +81,8 @@ module GecodeBuild
     system(*configure_cmd) &&
       system("make", "clean") &&
       system("make", "-j", "5") &&
-      system("make", "install")
+      system("make", "install") &&
+      system("make", "distclean")
   end
 
   def self.run


### PR DESCRIPTION
Run distclean for gecode.  I don't think the intermediate build
artifacts should be needed and they take up around 500MB of space
when the gem is installed.
