### PR TITLE
use gcc44 on older rhel systems

### DIFF
--- a/ext/libgecode3/extconf.rb
+++ b/ext/libgecode3/extconf.rb
@@ -47,6 +47,10 @@ module GecodeBuild
     if windows?
       ENV['CC'] = 'gcc'
       ENV['CXX'] = 'g++'
+    # Older versions of CentOS and RHEL need to use this
+    elsif File.exist?('/usr/bin/gcc44')
+      ENV['CC'] = 'gcc44'
+      ENV['CXX'] = 'g++44'
     end
 
     # Configure the gecode libraries to look for other gecode libraries in the


### PR DESCRIPTION
Please test this, as I ran into some problems trying to get a CentOS 5 VM running and haven't actually tried building it. /cc @danielsdeleo 
