### PR TITLE
fixed not to use cl.exe of CYGWIN

### DIFF
--- a/ext/libgecode3/vendor/gecode-3.7.3/configure
+++ b/ext/libgecode3/vendor/gecode-3.7.3/configure
@@ -2712,7 +2712,9 @@ $as_echo "Windows" >&6; }
        ;;
      esac
 
-if test "${CXX}x" = "x" -a "${CC}x" = "x" -a "${host_os}" = "windows"; then
+if test `uname -s | cut -c 1-6` = "CYGWIN"; then
+  echo "CYGWIN is not Windows!"
+elif test "${CXX}x" = "x" -a "${CC}x" = "x" -a "${host_os}" = "windows"; then
   CC=cl
   CXX=cl
 fi


### PR DESCRIPTION
I am going to install Berkshelf on CYGWIN, but do not get along well.
After checking it, it was a problem that the judgment of the OS was going to use cl.exe in the case of Windows in configure of dep-selector-libgecode.
I made modifications not to use cl.exe in the case of CYGWIN.