### PR TITLE
Use default number of parallel jobs

### DIFF
--- a/ext/libgecode3/extconf.rb
+++ b/ext/libgecode3/extconf.rb
@@ -88,7 +88,7 @@ module GecodeBuild
     patch_configure
     system(*configure_cmd) &&
       system("make", "clean") &&
-      system("make", "-j", "5") &&
+      system("make") &&
       system("make", "install") &&
       system("make", "distclean")
   end


### PR DESCRIPTION
Sometime we use not very super buper hardware. And 5 parallel compile workers eat memory and CPU.
So the simple instance from Digital Ocean could not build the gem.

```
virtual memory exhausted: Cannot allocate memory
make[1]: *** [gecode/int/count.o] Error 1
make[1]: *** Waiting for unfinished jobs....
g++: internal compiler error: Killed (program cc1plus)
```

To change the number of jobs, you can provide via env: `MAKEOPTS ='-j 5'`