### PR TITLE
Configure Window’s environments to use `bsdtar`

### DIFF
--- a/ext/libgecode3/extconf.rb
+++ b/ext/libgecode3/extconf.rb
@@ -48,6 +48,9 @@ module GecodeBuild
       ENV['CC'] = 'gcc'
       ENV['CXX'] = 'g++'
 
+      # Ruby DevKit ships with BSD Tar
+      ENV['PROG_TAR'] ||= 'bsdtar'
+
       # Optimize for size on Windows
       ENV['CFLAGS'] = '-Os'
       ENV['CXXFLAGS'] = '-Os'


### PR DESCRIPTION
The Ruby DevKit ships with `bsdtar` instead of `tar`. This change just ensures the environment is configured to use it.

Up until this point we have gotten lucky as our ChefDK builds build Chef first which in turn copies `bsdtar.exe` over to `tar.exe`:
https://github.com/opscode/omnibus-chef/blob/master/config/software/chef.rb#L61

/cc @opscode/client-engineers @opscode/release-engineers 
