### PR TITLE
fix for SmartOS (all SunOS), fixes #34

### DIFF
--- a/ext/libgecode3/extconf.rb
+++ b/ext/libgecode3/extconf.rb
@@ -12,6 +12,10 @@ module GecodeBuild
   def self.windows?
    !!(RUBY_PLATFORM =~ /mswin|mingw|windows/)
   end
+  
+  def self.sunos?
+    `uname`.strip == 'SunOS'
+  end
 
   def self.gecode_vendor_dir
     GECODE_VENDOR_DIR
@@ -40,6 +44,7 @@ module GecodeBuild
       --disable-flatzinc
     ]
     args << "--with-host-os=windows" if windows?
+    args << "--with-host-os=Linux" if sunos?
     args
   end
 


### PR DESCRIPTION
if you look at https://github.com/chef/dep-selector-libgecode/issues/34#issuecomment-67898575, you can see that a lot of lying about the underlying operating system is already taking place... this just adds `SunOS` to that list of lies.

With this I'm able to compile on SmartOS, which is the first step in getting omnibus-chef to work.
