### PR TITLE
Compile on Windows with passed-in flags

### DIFF
--- a/ext/libgecode3/extconf.rb
+++ b/ext/libgecode3/extconf.rb
@@ -45,15 +45,15 @@ module GecodeBuild
 
   def self.setup_env
     if windows?
-      ENV['CC'] = 'gcc'
-      ENV['CXX'] = 'g++'
+      ENV['CC'] ||= 'gcc'
+      ENV['CXX'] ||= 'g++'
 
       # Ruby DevKit ships with BSD Tar
       ENV['PROG_TAR'] ||= 'bsdtar'
 
       # Optimize for size on Windows
-      ENV['CFLAGS'] = '-Os'
-      ENV['CXXFLAGS'] = '-Os'
+      ENV['CFLAGS'] += ' -Os'
+      ENV['CXXFLAGS'] += ' -Os'
     # Older versions of CentOS and RHEL need to use this
     elsif File.exist?('/usr/bin/gcc44')
       ENV['CC'] = 'gcc44'

--- a/ext/libgecode3/extconf.rb
+++ b/ext/libgecode3/extconf.rb
@@ -52,8 +52,10 @@ module GecodeBuild
       ENV['PROG_TAR'] ||= 'bsdtar'
 
       # Optimize for size on Windows
-      ENV['CFLAGS'] += ' -Os'
-      ENV['CXXFLAGS'] += ' -Os'
+      ENV['CFLAGS'] ||= ""
+      ENV['CFLAGS'] << " -Os"
+      ENV['CXXFLAGS'] ||= ""
+      ENV['CXXFLAGS'] << " -Os"
     # Older versions of CentOS and RHEL need to use this
     elsif File.exist?('/usr/bin/gcc44')
       ENV['CC'] = 'gcc44'

--- a/ext/libgecode3/extconf.rb
+++ b/ext/libgecode3/extconf.rb
@@ -52,10 +52,8 @@ module GecodeBuild
       ENV['PROG_TAR'] ||= 'bsdtar'
 
       # Optimize for size on Windows
-      ENV['CFLAGS'] ||= ""
-      ENV['CFLAGS'] << " -Os"
-      ENV['CXXFLAGS'] ||= ""
-      ENV['CXXFLAGS'] << " -Os"
+      ENV['CFLAGS'] = "#{ENV['CFLAGS']} -Os"
+      ENV['CXXFLAGS'] = "#{ENV['CXXFLAGS']} -Os"
     # Older versions of CentOS and RHEL need to use this
     elsif File.exist?('/usr/bin/gcc44')
       ENV['CC'] = 'gcc44'


### PR DESCRIPTION
When we move a compiled ruby, we need to pass architecture flags to dep-selector-libgecode. Environment variables aren't being respected currently; this fixes that.