### PR TITLE
Fix building issues on newer Debian and Ubuntu platforms

### DIFF
--- a/ext/libgecode3/extconf.rb
+++ b/ext/libgecode3/extconf.rb
@@ -112,7 +112,13 @@ module GecodeBuild
   def self.run_build_commands
     setup_env
     patch_configure
-    system(*configure_cmd) &&
+    system("libtoolize --force") &&
+      system("aclocal") &&
+      system("autoheader") &&
+      system("automake --force-missing --add-missing || true") &&
+      system("autoconf") &&
+      system("autoupdate gecode.m4") &&
+      system(*configure_cmd) &&
       system("make", "clean") &&
       system("make", "-j", (num_processors + 1).to_s) &&
       system("make", "install") &&

--- a/ext/libgecode3/vendor/gecode-3.7.3/configure.ac
+++ b/ext/libgecode3/vendor/gecode-3.7.3/configure.ac
@@ -42,6 +42,8 @@ dnl
 AC_REVISION([$Id: configure.ac 12624 2012-03-22 21:55:28Z tack $])
 AC_PREREQ(2.53)
 AC_INIT(GECODE, 3.7.3, users@gecode.org)
+AM_INIT_AUTOMAKE([])
+AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_HEADERS([gecode/support/config.hpp])
 AC_CONFIG_SRCDIR(gecode/kernel.hh)
 


### PR DESCRIPTION
This fixes the following error message when trying to build on Debian 12 or Ubuntu
22.04:

```
configure: error: cannot find required auxiliary files: config.guess config.sub
```

You can see an example of how this is currently failing here:
https://gitlab.com/cinc-project/distribution/workstation/-/jobs/4914915772

I suspect this is due to the fact that this gem uses an ancient version of
gecode which hasn't been updated to work on newer platforms and we're now
running into issues after all these years.

The build commands will update the configure and Makefile scripts so that it
works properly on the platform it's building on. The other changes in
configure.ac are needed to also make those command work without any issues.

Signed-off-by: Lance Albertson <lance@osuosl.org>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
