### PR TITLE
Don't use libtoolize on Windows

### DIFF
--- a/ext/libgecode3/extconf.rb
+++ b/ext/libgecode3/extconf.rb
@@ -112,17 +112,26 @@ module GecodeBuild
   def self.run_build_commands
     setup_env
     patch_configure
-    system("libtoolize --force") &&
-      system("aclocal") &&
-      system("autoheader") &&
-      system("automake --force-missing --add-missing || true") &&
-      system("autoconf") &&
-      system("autoupdate gecode.m4") &&
+    case RbConfig::CONFIG['host_os']
+    when /mswin|mingw/
       system(*configure_cmd) &&
-      system("make", "clean") &&
-      system("make", "-j", (num_processors + 1).to_s) &&
-      system("make", "install") &&
-      system("make", "distclean")
+        system("make", "clean") &&
+        system("make", "-j", (num_processors + 1).to_s) &&
+        system("make", "install") &&
+        system("make", "distclean")
+    else
+      system("libtoolize --force") &&
+        system("aclocal") &&
+        system("autoheader") &&
+        system("automake --force-missing --add-missing || true") &&
+        system("autoconf") &&
+        system("autoupdate gecode.m4") &&
+        system(*configure_cmd) &&
+        system("make", "clean") &&
+        system("make", "-j", (num_processors + 1).to_s) &&
+        system("make", "install") &&
+        system("make", "distclean")
+    end
   end
 
   def self.run


### PR DESCRIPTION
This breaks builds on windows and it seems to work with the old method

Signed-off-by: Lance Albertson <lance@osuosl.org>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
